### PR TITLE
Add meetings associations to company and contact streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+**.ipynb
 
 # IPython
 profile_default/

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -278,13 +278,6 @@ class HubSpotStream(RESTStream):
         # Need to copy the replication key to top level so that meltano can read it
         if self.replication_key:
             row[self.replication_key] = self.get_replication_key_value(row)
-        # Convert properties and associations back into JSON
-        if "properties" in row:
-            jsonprops = json.dumps(row.get("properties"))
-            row["properties"] = jsonprops
-        if "associations" in row:
-            jsonassoc = json.dumps(row.get("associations"))
-            row["associations"] = jsonassoc
         return row
 
     def get_replication_key_value(self, row: dict) -> Optional[datetime]:

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -262,6 +262,7 @@ class HubSpotStream(RESTStream):
                     ]
                 }
             ]
+        self.logger.info(f"Request Payload: {body}")
         return body
 
     def get_appropriate_replication_key_value(

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -77,7 +77,7 @@ class HubSpotStream(RESTStream):
         """
         yes_search = not self.config.get("no_search", False)
         return yes_search and self.replication_method == REPLICATION_INCREMENTAL
-    
+
     # Override this property to disable sorting checks, Hubspot API sometimes returns unsorted data. Open issue here:
     # https://community.hubspot.com/t5/APIs-Integrations/Search-API-ascending-sort-does-not-work-descending-does/m-p/922945
     # This is a workaround to avoid the issue, but risks skipping records.

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -75,7 +75,8 @@ class HubSpotStream(RESTStream):
             `True` if stream is sorted. Defaults to `False`.
         """
         yes_search = not self.config.get("no_search", False)
-        return yes_search and self.replication_method == REPLICATION_INCREMENTAL
+        # return yes_search and self.replication_method == REPLICATION_INCREMENTAL
+        return False
 
     @property
     def authenticator(self) -> BearerTokenAuthenticator:

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -76,7 +76,7 @@ class HubSpotStream(RESTStream):
         """
         yes_search = not self.config.get("no_search", False)
         # return yes_search and self.replication_method == REPLICATION_INCREMENTAL
-        return False
+        return False # False for now, hubspot api seems to return unsorted results on rare occasions
 
     @property
     def authenticator(self) -> BearerTokenAuthenticator:

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -1,5 +1,5 @@
 """REST client handling, including HubSpotStream base class."""
-
+import re
 import gzip
 import json
 import logging
@@ -164,6 +164,8 @@ class HubSpotStream(RESTStream):
         }
         props_to_get = self.get_properties()
         if props_to_get:
+            # filter out properties like hs_date_entered_121383958, hs_date_exited_25023851
+            props_to_get = [s for s in props_to_get if not re.search(r".*_[0-9]{4,}$", s)]
             params["properties"] = props_to_get
         if next_page_token:
             params["after"] = next_page_token
@@ -233,7 +235,6 @@ class HubSpotStream(RESTStream):
                     ]
                 }
             ]
-
         return body
 
     def get_appropriate_replication_key_value(

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -93,6 +93,10 @@ class HubSpotStream(RESTStream):
         # headers["Private-Token"] = self.config.get("auth_token")
         return headers
 
+    def backoff_max_tries(self) -> int:
+        """Override this property to set the maximum number of backoff attempts."""
+        return 20
+
     def get_new_paginator(self) -> BaseAPIPaginator:
         """Get a fresh paginator for this API endpoint.
 

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -138,13 +138,17 @@ class HubSpotStream(RESTStream):
 
             old_replication_key_value = state_dict.get("replication_key_value", None)
             if old_replication_key_value:
-                # truncate states to minute
+                """ 
+                truncate states to minute, hubspot api occasionally returns records out of order by a few seconds
+                despite sorting in the request. This is a workaround to compare state timestamps at the minute level
+                to avoid the InvalidStreamSortException
+                """
                 old_replication_key_value = parser.parse(old_replication_key_value).strftime("%Y-%m-%d %H:%M")
                 latest_replication_key_value = latest_record[self.replication_key].strftime("%Y-%m-%d %H:%M")
 
                 state_dict["replication_key_value"] = old_replication_key_value
                 latest_record[self.replication_key] = latest_replication_key_value
-                
+
             increment_state(
                 state_dict,
                 replication_key=self.replication_key,

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -262,7 +262,7 @@ class HubSpotStream(RESTStream):
                     ]
                 }
             ]
-        self.logger.info(f"Request Payload: {body}")
+        # self.logger.info(f"Request Payload: {body}")
         return body
 
     def get_appropriate_replication_key_value(

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -77,6 +77,22 @@ class HubSpotStream(RESTStream):
         """
         yes_search = not self.config.get("no_search", False)
         return yes_search and self.replication_method == REPLICATION_INCREMENTAL
+    
+    # Override this property to disable sorting checks, Hubspot API sometimes returns unsorted data. Open issue here:
+    # https://community.hubspot.com/t5/APIs-Integrations/Search-API-ascending-sort-does-not-work-descending-does/m-p/922945
+    # This is a workaround to avoid the issue, but risks skipping records.
+    # This solution is implemented in the original tap-hubspot repo here: https://github.com/YouCruit/tap-hubspot/pull/24
+    @property
+    def check_sorted(self) -> bool:
+        """Check if stream is sorted.
+
+        This setting enables additional checks which may trigger
+        `InvalidStreamSortException` if records are found which are unsorted.
+
+        Returns:
+            `True` if sorting is checked. Defaults to `True`.
+        """
+        return False
 
     @property
     def authenticator(self) -> BearerTokenAuthenticator:

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -127,6 +127,8 @@ class HubSpotStream(RESTStream):
                 # Record filtered out during post_process()
                 continue
             yield transformed_record
+        # deallocate records
+        record, records = None, None
     
     def backoff_max_tries(self) -> int:
         """Override this property to set the maximum number of backoff attempts."""

--- a/tap_hubspot/helpers.py
+++ b/tap_hubspot/helpers.py
@@ -1,0 +1,51 @@
+from dateutil import parser
+from singer_sdk.exceptions import InvalidStreamSortException
+from singer_sdk.helpers._typing import to_json_compatible
+PROGRESS_MARKERS = "progress_markers"
+PROGRESS_MARKER_NOTE = "Note"
+
+def increment_state(
+    stream_or_partition_state: dict,
+    *,
+    latest_record: dict,
+    replication_key: str,
+    is_sorted: bool,
+    check_sorted: bool,
+) -> None:
+    """Update the state using data from the latest record.
+
+    Raises InvalidStreamSortException if is_sorted=True, check_sorted=True and unsorted
+    data is detected in the stream.
+    """
+    progress_dict = stream_or_partition_state
+    if not is_sorted:
+        if PROGRESS_MARKERS not in stream_or_partition_state:
+            stream_or_partition_state[PROGRESS_MARKERS] = {
+                PROGRESS_MARKER_NOTE: "Progress is not resumable if interrupted.",
+            }
+        progress_dict = stream_or_partition_state[PROGRESS_MARKERS]
+    old_rk_value = to_json_compatible(progress_dict.get("replication_key_value"))
+    new_rk_value = to_json_compatible(latest_record[replication_key])
+
+    """ 
+    truncate states to minute, hubspot api occasionally returns records out of order by a few seconds
+    despite sorting in the request. This is a workaround to compare state timestamps at the minute level
+    to avoid the InvalidStreamSortException
+    """
+    
+    if (
+        old_rk_value is None
+        or not check_sorted
+        or parser.parse(new_rk_value).strftime("%Y-%m-%d %H:%M")
+        >= parser.parse(old_rk_value).strftime("%Y-%m-%d %H:%M")
+    ):
+        progress_dict["replication_key"] = replication_key
+        progress_dict["replication_key_value"] = new_rk_value
+        return
+
+    if is_sorted:
+        msg = (
+            f"Unsorted data detected in stream. Latest value '{new_rk_value}' is "
+            f"smaller than previous max '{old_rk_value}'."
+        )
+        raise InvalidStreamSortException(msg)

--- a/tap_hubspot/streams/archived_companies.py
+++ b/tap_hubspot/streams/archived_companies.py
@@ -1,0 +1,90 @@
+from typing import Optional, Any, Dict
+
+from singer_sdk import typing as th  # JSON Schema typing helpers
+
+from tap_hubspot.client import HubSpotStream
+
+
+class ArchivedCompaniesStream(HubSpotStream):
+    """Archived Companies."""
+
+    name = "archived_companies"
+    full_path = "/crm/v3/objects/companies"  # full table replication, we can use the non-search endpoint
+    properties_object_type = "companies"
+    primary_keys = ["id"]
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params["archived"] = True
+        return params
+
+    @property
+    def schema(self):
+        props = th.PropertiesList(
+            th.Property(
+                "id",
+                th.StringType,
+            ),
+            th.Property(
+                "properties",
+                th.ObjectType(),
+            ),
+            th.Property(
+                "createdAt",
+                th.DateTimeType,
+            ),
+            th.Property(
+                "updatedAt",
+                th.DateTimeType,
+            ),
+            th.Property(
+                "archived",
+                th.BooleanType,
+            ),
+            th.Property(
+                "archivedAt",
+                th.DateTimeType,
+            ),
+            th.Property(
+                "associations",
+                th.ObjectType(),
+            ),
+        )
+
+        if self.replication_key:
+            props.append(
+                th.Property(
+                    self.replication_key,
+                    th.DateTimeType,
+                )
+            )
+        else:
+            props.append(
+                th.Property(
+                    "hs_lastmodifieddate",
+                    th.DateTimeType,
+                )
+            )
+
+        return props.to_dict()
+
+    @property
+    def replication_key(self) -> Optional[str]:
+        # for full table replication, we don't need a replication key
+        return None
+
+    @replication_key.setter
+    def replication_key(self, _):
+        "Just to shut Lint up"
+        pass
+
+    @property
+    def path(self) -> str:
+        return self.full_path
+
+    @path.setter
+    def path(self, _):
+        "Just to shut Lint up"
+        pass

--- a/tap_hubspot/streams/calls.py
+++ b/tap_hubspot/streams/calls.py
@@ -23,7 +23,7 @@ class CallsStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class CallsStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -3,6 +3,7 @@ from typing import Optional
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
+import logging
 
 
 class CompaniesStream(HubSpotStream):
@@ -55,6 +56,13 @@ class CompaniesStream(HubSpotStream):
                     th.DateTimeType,
                 )
             )
+        else:
+            props.append(
+                th.Property(
+                    "hs_lastmodifieddate",
+                    th.DateTimeType,
+                )
+            )
 
         return props.to_dict()
 
@@ -86,6 +94,7 @@ class CompaniesStream(HubSpotStream):
             row[self.replication_key] = self.get_replication_key_value(row)
         else:
             row["hs_lastmodifieddate"] = row['updatedAt']
+        # logging.info(f"Post processing row: {row}")
         return row
 
     # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -76,3 +76,9 @@ class CompaniesStream(HubSpotStream):
     def path(self, _):
         "Just to shut Lint up"
         pass
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "id": record["id"],
+        }

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -9,7 +9,8 @@ class CompaniesStream(HubSpotStream):
     """Companies."""
 
     name = "companies"
-    search_path = "/crm/v3/objects/companies/search"
+    # search_path = "/crm/v3/objects/companies/search"
+    search_path = "/crm/v3/objects/companies"
     full_path = "/crm/v3/objects/companies"
     properties_object_type = "companies"
     primary_keys = ["id"]
@@ -59,7 +60,8 @@ class CompaniesStream(HubSpotStream):
 
     @property
     def replication_key(self) -> Optional[str]:
-        return None if self.config.get("no_search", False) else "hs_lastmodifieddate"
+        return None
+        # return None if self.config.get("no_search", False) else "hs_lastmodifieddate"
 
     @replication_key.setter
     def replication_key(self, _):

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -9,8 +9,8 @@ class CompaniesStream(HubSpotStream):
     """Companies."""
 
     name = "companies"
-    # search_path = "/crm/v3/objects/companies/search"
-    search_path = "/crm/v3/objects/companies"
+    search_path = "/crm/v3/objects/companies/search"
+    # search_path = "/crm/v3/objects/companies"
     full_path = "/crm/v3/objects/companies"
     properties_object_type = "companies"
     primary_keys = ["id"]

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -67,8 +67,7 @@ class CompaniesStream(HubSpotStream):
 
     @property
     def replication_key(self) -> Optional[str]:
-        return None
-        # return None if self.config.get("no_search", False) else "hs_lastmodifieddate"
+        return None if self.config.get("no_search", False) else "hs_lastmodifieddate"
 
     @replication_key.setter
     def replication_key(self, _):

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -79,6 +79,15 @@ class CompaniesStream(HubSpotStream):
         "Just to shut Lint up"
         pass
 
+    def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
+        """As needed, append or transform raw data to match expected structure."""
+        # Need to copy the replication key to top level so that meltano can read it
+        if self.replication_key:
+            row[self.replication_key] = self.get_replication_key_value(row)
+        else:
+            row["hs_lastmodifieddate"] = row['updatedAt']
+        return row
+
     # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
     #     """Return a context dictionary for child streams."""
     #     return {

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -23,7 +23,7 @@ class CompaniesStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class CompaniesStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -77,8 +77,8 @@ class CompaniesStream(HubSpotStream):
         "Just to shut Lint up"
         pass
 
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a context dictionary for child streams."""
-        return {
-            "id": record["id"],
-        }
+    # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+    #     """Return a context dictionary for child streams."""
+    #     return {
+    #         "id": record["id"],
+    #     }

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -3,7 +3,6 @@ from typing import Optional
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
-import logging
 
 
 class CompaniesStream(HubSpotStream):
@@ -94,7 +93,6 @@ class CompaniesStream(HubSpotStream):
             row[self.replication_key] = self.get_replication_key_value(row)
         else:
             row["hs_lastmodifieddate"] = row['updatedAt']
-        # logging.info(f"Post processing row: {row}")
         return row
 
     # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:

--- a/tap_hubspot/streams/company_associations.py
+++ b/tap_hubspot/streams/company_associations.py
@@ -6,8 +6,8 @@ from tap_hubspot.streams.companies import CompaniesStream
 
 class CompanyAssociationsStream(HubSpotStream):
     """Company's associations."""
-    parent_stream_type = CompaniesStream
-    records_jsonpath = "$[*]"
+    # parent_stream_type = CompaniesStream
+    # records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -16,7 +16,8 @@ class CompanyAssociationsStream(HubSpotStream):
 
     name = "company_associations"
     path = (
-        "/crm/v4/objects/company/{id}/?associations=contacts,deals"
+        # "/crm/v4/objects/company/{id}/?associations=contacts,deals"
+        "/crm/v4/objects/company/?associations=contacts,deals"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "companies"

--- a/tap_hubspot/streams/company_associations.py
+++ b/tap_hubspot/streams/company_associations.py
@@ -44,4 +44,8 @@ class CompanyAssociationsStream(HubSpotStream):
             "propertiesWithHistory",
             th.ObjectType(),
         ),
+        th.Property(
+            "properties",
+            th.ObjectType(),
+        ),
     ).to_dict()

--- a/tap_hubspot/streams/company_associations.py
+++ b/tap_hubspot/streams/company_associations.py
@@ -17,7 +17,7 @@ class CompanyAssociationsStream(HubSpotStream):
     name = "company_associations"
     path = (
         # "/crm/v4/objects/company/{id}/?associations=contacts,deals"
-        "/crm/v4/objects/company/?associations=contacts,deals"
+        "/crm/v4/objects/company/?associations=contacts,deals,meetings"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "companies"

--- a/tap_hubspot/streams/company_associations.py
+++ b/tap_hubspot/streams/company_associations.py
@@ -34,10 +34,10 @@ class CompanyAssociationsStream(HubSpotStream):
         ),
         th.Property(
             "associations",
-            th.StringType,
+            th.ObjectType(),
         ),
         th.Property(
             "propertiesWithHistory",
-            th.StringType,
+            th.ObjectType(),
         ),
     ).to_dict()

--- a/tap_hubspot/streams/company_associations.py
+++ b/tap_hubspot/streams/company_associations.py
@@ -1,10 +1,13 @@
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
+from tap_hubspot.streams.companies import CompaniesStream
 
 
 class CompanyAssociationsStream(HubSpotStream):
     """Company's associations."""
+    parent_stream_type = CompaniesStream
+    records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -13,7 +16,7 @@ class CompanyAssociationsStream(HubSpotStream):
 
     name = "company_associations"
     path = (
-        "/crm/v4/objects/company/?associations=contacts,deals"
+        "/crm/v4/objects/company/{id}/?associations=contacts,deals"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "companies"

--- a/tap_hubspot/streams/contact_associations.py
+++ b/tap_hubspot/streams/contact_associations.py
@@ -18,7 +18,7 @@ class ContactAssociationsStream(HubSpotStream):
     name = "contact_associations"
     path = (
         # "/crm/v4/objects/contact/{id}/?associations=companies,deals"
-        "/crm/v4/objects/contact/?associations=companies,deals"
+        "/crm/v4/objects/contact/?associations=companies,deals,meetings"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "contacts"

--- a/tap_hubspot/streams/contact_associations.py
+++ b/tap_hubspot/streams/contact_associations.py
@@ -7,8 +7,8 @@ from tap_hubspot.streams.contacts import ContactsStream
 class ContactAssociationsStream(HubSpotStream):
     """Contact's associations."""
 
-    parent_stream_type = ContactsStream
-    records_jsonpath = "$[*]"
+    # parent_stream_type = ContactsStream
+    # records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -17,7 +17,8 @@ class ContactAssociationsStream(HubSpotStream):
 
     name = "contact_associations"
     path = (
-        "/crm/v4/objects/contact/{id}/?associations=companies,deals"
+        # "/crm/v4/objects/contact/{id}/?associations=companies,deals"
+        "/crm/v4/objects/contact/?associations=companies,deals"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "contacts"

--- a/tap_hubspot/streams/contact_associations.py
+++ b/tap_hubspot/streams/contact_associations.py
@@ -1,10 +1,14 @@
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
+from tap_hubspot.streams.contacts import ContactsStream
 
 
 class ContactAssociationsStream(HubSpotStream):
     """Contact's associations."""
+
+    parent_stream_type = ContactsStream
+    records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -13,7 +17,7 @@ class ContactAssociationsStream(HubSpotStream):
 
     name = "contact_associations"
     path = (
-        "/crm/v4/objects/contact/?associations=companies,deals"
+        "/crm/v4/objects/contact/{id}/?associations=companies,deals"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "contacts"

--- a/tap_hubspot/streams/contact_associations.py
+++ b/tap_hubspot/streams/contact_associations.py
@@ -34,10 +34,10 @@ class ContactAssociationsStream(HubSpotStream):
         ),
         th.Property(
             "associations",
-            th.StringType,
+            th.ObjectType(),
         ),
         th.Property(
             "propertiesWithHistory",
-            th.StringType,
+            th.ObjectType(),
         ),
     ).to_dict()

--- a/tap_hubspot/streams/contact_associations.py
+++ b/tap_hubspot/streams/contact_associations.py
@@ -45,4 +45,8 @@ class ContactAssociationsStream(HubSpotStream):
             "propertiesWithHistory",
             th.ObjectType(),
         ),
+        th.Property(
+            "properties",
+            th.ObjectType(),
+        ),
     ).to_dict()

--- a/tap_hubspot/streams/contacts.py
+++ b/tap_hubspot/streams/contacts.py
@@ -23,7 +23,7 @@ class ContactsStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class ContactsStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/contacts.py
+++ b/tap_hubspot/streams/contacts.py
@@ -47,25 +47,6 @@ class ContactsStream(HubSpotStream):
             ),
         )
 
-        # Needs to be defined manually since 2023-07-12 when
-        # the list of properties in hubspot became to long for a request.
-        # Error: 414 Client Error: URI Too Long for path
-        self.extra_properties = [
-            "email",
-            "firstname",
-            "lastname",
-            "jobtitle",
-            "call_center_candidate_id",
-            "candidate_id",
-            "interested_in_lanefinder_driver_force",
-            "hs_last_sales_activity_timestamp",
-            "hs_lead_status",
-            "hs_searchable_calculated_international_mobile_number",
-            "hubspot_owner_id",
-            "hs_calculated_phone_number",
-            "hs_timezone",
-        ]
-
         if self.replication_key:
             props.append(
                 th.Property(

--- a/tap_hubspot/streams/contacts.py
+++ b/tap_hubspot/streams/contacts.py
@@ -96,8 +96,8 @@ class ContactsStream(HubSpotStream):
         "Just to shut Lint up"
         pass
 
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a context dictionary for child streams."""
-        return {
-            "id": record["id"],
-        }
+    # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+    #     """Return a context dictionary for child streams."""
+    #     return {
+    #         "id": record["id"],
+    #     }

--- a/tap_hubspot/streams/contacts.py
+++ b/tap_hubspot/streams/contacts.py
@@ -95,3 +95,9 @@ class ContactsStream(HubSpotStream):
     def path(self, _):
         "Just to shut Lint up"
         pass
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "id": record["id"],
+        }

--- a/tap_hubspot/streams/deals.py
+++ b/tap_hubspot/streams/deals.py
@@ -77,8 +77,8 @@ class DealsStream(HubSpotStream):
         "Just to shut Lint up"
         pass
 
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a context dictionary for child streams."""
-        return {
-            "id": record["id"],
-        }
+    # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+    #     """Return a context dictionary for child streams."""
+    #     return {
+    #         "id": record["id"],
+    #     }

--- a/tap_hubspot/streams/deals.py
+++ b/tap_hubspot/streams/deals.py
@@ -23,7 +23,7 @@ class DealsStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class DealsStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/deals.py
+++ b/tap_hubspot/streams/deals.py
@@ -76,3 +76,9 @@ class DealsStream(HubSpotStream):
     def path(self, _):
         "Just to shut Lint up"
         pass
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "id": record["id"],
+        }

--- a/tap_hubspot/streams/deals_associations.py
+++ b/tap_hubspot/streams/deals_associations.py
@@ -44,4 +44,8 @@ class DealsAssociationsStream(HubSpotStream):
             "propertiesWithHistory",
             th.ObjectType(),
         ),
+        th.Property(
+            "properties",
+            th.ObjectType(),
+        ),
     ).to_dict()

--- a/tap_hubspot/streams/deals_associations.py
+++ b/tap_hubspot/streams/deals_associations.py
@@ -17,7 +17,7 @@ class DealsAssociationsStream(HubSpotStream):
     name = "deals_associations"
     path = (
         # "/crm/v4/objects/deal/{id}/?associations=companies,contacts"
-        "/crm/v4/objects/deal/?associations=companies,contacts"
+        "/crm/v4/objects/deal/?associations=companies,contacts,tasks"
         "&propertiesWithHistory=hubspot_owner_id,dealstage"
     )
     properties_object_type = "deals"

--- a/tap_hubspot/streams/deals_associations.py
+++ b/tap_hubspot/streams/deals_associations.py
@@ -1,10 +1,13 @@
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
+from tap_hubspot.streams.deals import DealsStream
 
 
 class DealsAssociationsStream(HubSpotStream):
     """Deal's associations"""
+    parent_stream_type = DealsStream
+    records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -13,7 +16,7 @@ class DealsAssociationsStream(HubSpotStream):
 
     name = "deals_associations"
     path = (
-        "/crm/v4/objects/deal/?associations=companies,contacts"
+        "/crm/v4/objects/deal/{id}/?associations=companies,contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "deals"
@@ -37,7 +40,7 @@ class DealsAssociationsStream(HubSpotStream):
             th.ObjectType(),
         ),
         th.Property(
-            "associations",
+            "propertiesWithHistory",
             th.ObjectType(),
         ),
     ).to_dict()

--- a/tap_hubspot/streams/deals_associations.py
+++ b/tap_hubspot/streams/deals_associations.py
@@ -34,10 +34,10 @@ class DealsAssociationsStream(HubSpotStream):
         ),
         th.Property(
             "associations",
-            th.StringType,
+            th.ObjectType(),
         ),
         th.Property(
             "associations",
-            th.StringType,
+            th.ObjectType(),
         ),
     ).to_dict()

--- a/tap_hubspot/streams/deals_associations.py
+++ b/tap_hubspot/streams/deals_associations.py
@@ -18,7 +18,7 @@ class DealsAssociationsStream(HubSpotStream):
     path = (
         # "/crm/v4/objects/deal/{id}/?associations=companies,contacts"
         "/crm/v4/objects/deal/?associations=companies,contacts"
-        "&propertiesWithHistory=hubspot_owner_id"
+        "&propertiesWithHistory=hubspot_owner_id,dealstage"
     )
     properties_object_type = "deals"
     primary_keys = ["id"]

--- a/tap_hubspot/streams/deals_associations.py
+++ b/tap_hubspot/streams/deals_associations.py
@@ -6,8 +6,8 @@ from tap_hubspot.streams.deals import DealsStream
 
 class DealsAssociationsStream(HubSpotStream):
     """Deal's associations"""
-    parent_stream_type = DealsStream
-    records_jsonpath = "$[*]"
+    # parent_stream_type = DealsStream
+    # records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -16,7 +16,8 @@ class DealsAssociationsStream(HubSpotStream):
 
     name = "deals_associations"
     path = (
-        "/crm/v4/objects/deal/{id}/?associations=companies,contacts"
+        # "/crm/v4/objects/deal/{id}/?associations=companies,contacts"
+        "/crm/v4/objects/deal/?associations=companies,contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "deals"

--- a/tap_hubspot/streams/email_associations.py
+++ b/tap_hubspot/streams/email_associations.py
@@ -6,8 +6,8 @@ from tap_hubspot.streams.emails import EmailsStream
 
 class EmailAssociationsStream(HubSpotStream):
     """Email's associations."""
-    parent_stream_type = EmailsStream
-    records_jsonpath = "$[*]"
+    # parent_stream_type = EmailsStream
+    # records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -16,7 +16,8 @@ class EmailAssociationsStream(HubSpotStream):
 
     name = "email_associations"
     path = (
-        "/crm/v4/objects/email/{id}/?associations=contacts"
+        # "/crm/v4/objects/email/{id}/?associations=contacts"
+        "/crm/v4/objects/email/?associations=contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "emails"

--- a/tap_hubspot/streams/email_associations.py
+++ b/tap_hubspot/streams/email_associations.py
@@ -1,0 +1,43 @@
+from singer_sdk import typing as th  # JSON Schema typing helpers
+
+from tap_hubspot.client import HubSpotStream
+
+
+class EmailAssociationsStream(HubSpotStream):
+    """Email's associations."""
+
+    def get_properties(self):
+        return []
+
+    request_limit = 50
+
+    name = "email_associations"
+    path = (
+        "/crm/v4/objects/email/?associations=contacts"
+        "&propertiesWithHistory=hubspot_owner_id"
+    )
+    properties_object_type = "emails"
+    primary_keys = ["id"]
+    replication_key = None
+    schema = th.PropertiesList(
+        th.Property(
+            "id",
+            th.StringType,
+        ),
+        th.Property(
+            "updatedAt",
+            th.DateTimeType,
+        ),
+        th.Property(
+            "archived",
+            th.BooleanType,
+        ),
+        th.Property(
+            "associations",
+            th.ObjectType(),
+        ),
+        th.Property(
+            "propertiesWithHistory",
+            th.ObjectType(),
+        ),
+    ).to_dict()

--- a/tap_hubspot/streams/email_associations.py
+++ b/tap_hubspot/streams/email_associations.py
@@ -44,4 +44,8 @@ class EmailAssociationsStream(HubSpotStream):
             "propertiesWithHistory",
             th.ObjectType(),
         ),
+        th.Property(
+            "properties",
+            th.ObjectType(),
+        ),
     ).to_dict()

--- a/tap_hubspot/streams/email_associations.py
+++ b/tap_hubspot/streams/email_associations.py
@@ -1,10 +1,13 @@
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
+from tap_hubspot.streams.emails import EmailsStream
 
 
 class EmailAssociationsStream(HubSpotStream):
     """Email's associations."""
+    parent_stream_type = EmailsStream
+    records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -13,7 +16,7 @@ class EmailAssociationsStream(HubSpotStream):
 
     name = "email_associations"
     path = (
-        "/crm/v4/objects/email/?associations=contacts"
+        "/crm/v4/objects/email/{id}/?associations=contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "emails"

--- a/tap_hubspot/streams/emails.py
+++ b/tap_hubspot/streams/emails.py
@@ -77,8 +77,8 @@ class EmailsStream(HubSpotStream):
         "Just to shut Lint up"
         pass
 
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a context dictionary for child streams."""
-        return {
-            "id": record["id"],
-        }
+    # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+    #     """Return a context dictionary for child streams."""
+    #     return {
+    #         "id": record["id"],
+    #     }

--- a/tap_hubspot/streams/emails.py
+++ b/tap_hubspot/streams/emails.py
@@ -23,7 +23,7 @@ class EmailsStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class EmailsStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/emails.py
+++ b/tap_hubspot/streams/emails.py
@@ -76,3 +76,9 @@ class EmailsStream(HubSpotStream):
     def path(self, _):
         "Just to shut Lint up"
         pass
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "id": record["id"],
+        }

--- a/tap_hubspot/streams/meetings.py
+++ b/tap_hubspot/streams/meetings.py
@@ -23,7 +23,7 @@ class MeetingsStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class MeetingsStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/notes.py
+++ b/tap_hubspot/streams/notes.py
@@ -23,7 +23,7 @@ class NotesStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class NotesStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/task_associations.py
+++ b/tap_hubspot/streams/task_associations.py
@@ -1,10 +1,13 @@
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
+from tap_hubspot.streams.tasks import TasksStream
 
 
 class TaskAssociationsStream(HubSpotStream):
     """Task's associations."""
+    parent_stream_type = TasksStream
+    records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -13,7 +16,7 @@ class TaskAssociationsStream(HubSpotStream):
 
     name = "task_associations"
     path = (
-        "/crm/v4/objects/task/?associations=contacts"
+        "/crm/v4/objects/task/{id}/?associations=contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "task"

--- a/tap_hubspot/streams/task_associations.py
+++ b/tap_hubspot/streams/task_associations.py
@@ -34,10 +34,10 @@ class TaskAssociationsStream(HubSpotStream):
         ),
         th.Property(
             "associations",
-            th.StringType,
+            th.ObjectType(),
         ),
         th.Property(
             "propertiesWithHistory",
-            th.StringType,
+            th.ObjectType(),
         ),
     ).to_dict()

--- a/tap_hubspot/streams/task_associations.py
+++ b/tap_hubspot/streams/task_associations.py
@@ -6,8 +6,8 @@ from tap_hubspot.streams.tasks import TasksStream
 
 class TaskAssociationsStream(HubSpotStream):
     """Task's associations."""
-    parent_stream_type = TasksStream
-    records_jsonpath = "$[*]"
+    # parent_stream_type = TasksStream
+    # records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -16,7 +16,8 @@ class TaskAssociationsStream(HubSpotStream):
 
     name = "task_associations"
     path = (
-        "/crm/v4/objects/task/{id}/?associations=contacts"
+        # "/crm/v4/objects/task/{id}/?associations=contacts"
+        "/crm/v4/objects/task/?associations=contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "task"

--- a/tap_hubspot/streams/task_associations.py
+++ b/tap_hubspot/streams/task_associations.py
@@ -44,4 +44,8 @@ class TaskAssociationsStream(HubSpotStream):
             "propertiesWithHistory",
             th.ObjectType(),
         ),
+        th.Property(
+            "properties",
+            th.ObjectType(),
+        ),
     ).to_dict()

--- a/tap_hubspot/streams/task_associations.py
+++ b/tap_hubspot/streams/task_associations.py
@@ -17,7 +17,7 @@ class TaskAssociationsStream(HubSpotStream):
     name = "task_associations"
     path = (
         # "/crm/v4/objects/task/{id}/?associations=contacts"
-        "/crm/v4/objects/task/?associations=contacts,deals"
+        "/crm/v4/objects/task/?associations=contacts,deals,companies,tickets"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "task"

--- a/tap_hubspot/streams/task_associations.py
+++ b/tap_hubspot/streams/task_associations.py
@@ -17,7 +17,7 @@ class TaskAssociationsStream(HubSpotStream):
     name = "task_associations"
     path = (
         # "/crm/v4/objects/task/{id}/?associations=contacts"
-        "/crm/v4/objects/task/?associations=contacts"
+        "/crm/v4/objects/task/?associations=contacts,deals"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "task"

--- a/tap_hubspot/streams/tasks.py
+++ b/tap_hubspot/streams/tasks.py
@@ -76,3 +76,9 @@ class TasksStream(HubSpotStream):
     def path(self, _):
         "Just to shut Lint up"
         pass
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "id": record["id"],
+        }

--- a/tap_hubspot/streams/tasks.py
+++ b/tap_hubspot/streams/tasks.py
@@ -23,7 +23,7 @@ class TasksStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class TasksStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/tasks.py
+++ b/tap_hubspot/streams/tasks.py
@@ -77,8 +77,8 @@ class TasksStream(HubSpotStream):
         "Just to shut Lint up"
         pass
 
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a context dictionary for child streams."""
-        return {
-            "id": record["id"],
-        }
+    # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+    #     """Return a context dictionary for child streams."""
+    #     return {
+    #         "id": record["id"],
+    #     }

--- a/tap_hubspot/streams/tickets.py
+++ b/tap_hubspot/streams/tickets.py
@@ -77,8 +77,8 @@ class TicketsStream(HubSpotStream):
         "Just to shut Lint up"
         pass
 
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a context dictionary for child streams."""
-        return {
-            "id": record["id"],
-        }
+    # def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+    #     """Return a context dictionary for child streams."""
+    #     return {
+    #         "id": record["id"],
+    #     }

--- a/tap_hubspot/streams/tickets.py
+++ b/tap_hubspot/streams/tickets.py
@@ -23,7 +23,7 @@ class TicketsStream(HubSpotStream):
             ),
             th.Property(
                 "properties",
-                th.StringType,
+                th.ObjectType(),
             ),
             th.Property(
                 "createdAt",
@@ -43,7 +43,7 @@ class TicketsStream(HubSpotStream):
             ),
             th.Property(
                 "associations",
-                th.StringType,
+                th.ObjectType(),
             ),
         )
 

--- a/tap_hubspot/streams/tickets.py
+++ b/tap_hubspot/streams/tickets.py
@@ -76,3 +76,9 @@ class TicketsStream(HubSpotStream):
     def path(self, _):
         "Just to shut Lint up"
         pass
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "id": record["id"],
+        }

--- a/tap_hubspot/streams/tickets_associations.py
+++ b/tap_hubspot/streams/tickets_associations.py
@@ -43,4 +43,8 @@ class TicketsAssociationsStream(HubSpotStream):
             "propertiesWithHistory",
             th.ObjectType(),
         ),
+        th.Property(
+            "properties",
+            th.ObjectType(),
+        ),
     ).to_dict()

--- a/tap_hubspot/streams/tickets_associations.py
+++ b/tap_hubspot/streams/tickets_associations.py
@@ -5,8 +5,8 @@ from tap_hubspot.streams.tickets import TicketsStream
 
 class TicketsAssociationsStream(HubSpotStream):
     """Ticket's associations."""
-    parent_stream_type = TicketsStream
-    records_jsonpath = "$[*]"
+    # parent_stream_type = TicketsStream
+    # records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -15,7 +15,8 @@ class TicketsAssociationsStream(HubSpotStream):
 
     name = "tickets_associations"
     path = (
-        "/crm/v4/objects/tickets/{id}/?associations=companies,contacts"
+        # "/crm/v4/objects/tickets/{id}/?associations=companies,contacts"
+        "/crm/v4/objects/tickets/?associations=companies,contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "tickets"

--- a/tap_hubspot/streams/tickets_associations.py
+++ b/tap_hubspot/streams/tickets_associations.py
@@ -34,10 +34,10 @@ class TicketsAssociationsStream(HubSpotStream):
         ),
         th.Property(
             "associations",
-            th.StringType,
+            th.ObjectType(),
         ),
         th.Property(
             "propertiesWithHistory",
-            th.StringType,
+            th.ObjectType(),
         ),
     ).to_dict()

--- a/tap_hubspot/streams/tickets_associations.py
+++ b/tap_hubspot/streams/tickets_associations.py
@@ -16,7 +16,7 @@ class TicketsAssociationsStream(HubSpotStream):
     name = "tickets_associations"
     path = (
         # "/crm/v4/objects/tickets/{id}/?associations=companies,contacts"
-        "/crm/v4/objects/tickets/?associations=companies,contacts"
+        "/crm/v4/objects/tickets/?associations=companies,contacts,deals,tasks"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "tickets"

--- a/tap_hubspot/streams/tickets_associations.py
+++ b/tap_hubspot/streams/tickets_associations.py
@@ -1,10 +1,12 @@
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import HubSpotStream
-
+from tap_hubspot.streams.tickets import TicketsStream
 
 class TicketsAssociationsStream(HubSpotStream):
     """Ticket's associations."""
+    parent_stream_type = TicketsStream
+    records_jsonpath = "$[*]"
 
     def get_properties(self):
         return []
@@ -13,7 +15,7 @@ class TicketsAssociationsStream(HubSpotStream):
 
     name = "tickets_associations"
     path = (
-        "/crm/v4/objects/tickets/?associations=companies,contacts"
+        "/crm/v4/objects/tickets/{id}/?associations=companies,contacts"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "tickets"

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -28,6 +28,7 @@ from tap_hubspot.streams.tasks import TasksStream
 from tap_hubspot.streams.tickets import TicketsStream
 from tap_hubspot.streams.tickets_associations import TicketsAssociationsStream
 from tap_hubspot.streams.tickets_pipelines import TicketsPipelinesStream
+from tap_hubspot.streams.email_associations import EmailAssociationsStream
 
 STREAM_TYPES = [
     CompaniesStream,
@@ -50,6 +51,7 @@ STREAM_TYPES = [
     ContactAssociationsStream,
     TaskAssociationsStream,
     TicketsAssociationsStream,
+    EmailAssociationsStream,
 ]
 
 

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -96,20 +96,20 @@ class TapHubSpot(Tap):
                 th.Property(
                     "encoding",
                     th.ObjectType(
-                        th.Property("format", th.StringType, required=True),
-                        th.Property("compression", th.StringType, required=True),
+                        th.Property("format", th.StringType, required=False),
+                        th.Property("compression", th.StringType, required=False),
                     ),
-                    required=True,
+                    required=False,
                 ),
                 th.Property(
                     "storage",
                     th.ObjectType(
-                        th.Property("root", th.StringType, required=True),
+                        th.Property("root", th.StringType, required=False),
                         th.Property(
                             "prefix", th.StringType, required=False, default=""
                         ),
                     ),
-                    required=True,
+                    required=False,
                 ),
             ),
             required=False,

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -106,7 +106,7 @@ class TapHubSpot(Tap):
                     th.ObjectType(
                         th.Property("root", th.StringType, required=False),
                         th.Property(
-                            "prefix", th.StringType, required=False, default=""
+                            "prefix", th.StringType, required=False,
                         ),
                     ),
                     required=False,

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -12,6 +12,7 @@ from singer_sdk.helpers.capabilities import (
     TapCapabilities,
 )
 
+from tap_hubspot.streams.archived_companies import ArchivedCompaniesStream
 from tap_hubspot.streams.calls import CallsStream
 from tap_hubspot.streams.companies import CompaniesStream
 from tap_hubspot.streams.company_associations import CompanyAssociationsStream
@@ -32,6 +33,7 @@ from tap_hubspot.streams.tickets_pipelines import TicketsPipelinesStream
 from tap_hubspot.streams.email_associations import EmailAssociationsStream
 
 STREAM_TYPES = [
+    ArchivedCompaniesStream,
     CompaniesStream,
     ContactsStream,
     DealsStream,


### PR DESCRIPTION
This PR adds meetings associations to both company and contact association streams, allowing the tap to extract meeting associations alongside existing contact and deal associations.